### PR TITLE
Fix minor formatting error in ConfigurationProfile.md

### DIFF
--- a/ConfigurationProfile.md
+++ b/ConfigurationProfile.md
@@ -125,7 +125,9 @@ Example:
 <true/>
 ```
 
-#### `totalDownloadBytes` : (Integer, optional, default: 1000000000 or 1GB, v0.8)
+#### `totalDownloadBytes`
+
+(Integer, optional, default: 1000000000 or 1GB, v0.8)
 
 Use this value to provide an estimate for the total size of all items that will be downloaded. Setup Manager will display and estimated download time for this sum in the "About this Mac..." popup window.
 


### PR DESCRIPTION
In totalDownloadBytes, the information about the parameters for the value appears on the same line as the header, unlike the rest of the document. This commit fixes that formatting (ever the editor…).